### PR TITLE
Send minified data instead of file

### DIFF
--- a/lib/mollify.js
+++ b/lib/mollify.js
@@ -32,8 +32,8 @@ function mollify(options, request, response, next) {
     if (!isExt || !isMinify)
         return next();
     
-    minify(name, 'name').then((name) => {
-        ponse.sendFile({
+    minify(name, 'name').then((data) => {
+        ponse.send(data, {
             request,
             response,
             name,


### PR DESCRIPTION
I recently integrated mollify into one of my projects.
In doing so, i realized that ponse tries to find a file that has the name of the minified data.
Instead, however, the `ponse.send(data, options)` method should be called with the minimized data.